### PR TITLE
Fix toast in version 1.20.2.

### DIFF
--- a/src/main/java/com/loohp/interactivechat/utils/ToastUtils.java
+++ b/src/main/java/com/loohp/interactivechat/utils/ToastUtils.java
@@ -178,7 +178,7 @@ public class ToastUtils {
             List<String[]> fixedRequirements = new ArrayList<>();
             fixedRequirements.add(new String[] {"for_free"});
             Object advRequirements;
-            if (InteractiveChat.version.isNewerOrEqualTo(MCVersion.V1_20_2)) {
+            if (InteractiveChat.version.isNewerOrEqualTo(MCVersion.V1_20_3)) {
                 advRequirements = fixedRequirements.stream().map(e -> Arrays.asList(e)).collect(Collectors.toList());
             } else {
                 advRequirements = Arrays.stream(fixedRequirements.toArray()).toArray(String[][]::new);


### PR DESCRIPTION
[19:32:59 INFO]: Checking version, please wait...
[19:32:59 INFO]: Current: git-Purpur-2095 (MC: 1.20.2)*
Previous: git-Purpur-2062 (MC: 1.20.1)
* You are running the latest version

```
[19:28:16 WARN]: java.lang.IllegalArgumentException: argument type mismatch
[19:28:16 WARN]:        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[19:28:16 WARN]:        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
[19:28:16 WARN]:        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[19:28:16 WARN]:        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[19:28:16 WARN]:        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
[19:28:16 WARN]:        at InteractiveChat-4.2.9.1.jar//com.loohp.interactivechat.utils.ToastUtils.mention(ToastUtils.java:189)
[19:28:16 WARN]:        at InteractiveChat-4.2.9.1.jar//com.loohp.interactivechat.modules.MentionDisplay.process(MentionDisplay.java:169)
[19:28:16 WARN]:        at InteractiveChat-4.2.9.1.jar//com.loohp.interactivechat.listeners.OutMessagePacket.processPacket(OutMessagePacket.java:624)
[19:28:16 WARN]:        at InteractiveChat-4.2.9.1.jar//com.loohp.interactivechat.listeners.OutMessagePacket.access$200(OutMessagePacket.java:83)
[19:28:16 WARN]:        at InteractiveChat-4.2.9.1.jar//com.loohp.interactivechat.listeners.OutMessagePacket$1.lambda$onPacketSending$0(OutMessagePacket.java:497)
[19:28:16 WARN]:        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
[19:28:16 WARN]:        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[19:28:16 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[19:28:16 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[19:28:16 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
```