### PR TITLE
Fix default servertime placeholder

### DIFF
--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -546,7 +546,7 @@ CustomPlaceholders:
       Value: ''
     Replace:
       Enable: true
-      ReplaceText: '%server_time_dd/MM/yyyy HH:mm:ss zzz%'
+      ReplaceText: '%servertime_dd/MM/yyyy HH:mm:ss zzz%'
     Name: "[time]"
     Description: "&eShows the current time of the server in the real world!"
   '6':


### PR DESCRIPTION
Since the placeholder of the [PAPI Servertime eCloud extension](https://api.extendedclip.com/expansions/servertime/) is ` %servertime_<SimpleDateFormat>%`, the current default config doesn't work even after installing all the necessary extensions. This PR addresses the issue.