### PR TITLE
Fix: Initialise platform automatically only if it is ProtocolLibPlatform

### DIFF
--- a/common/src/main/java/com/loohp/interactivechat/InteractiveChat.java
+++ b/common/src/main/java/com/loohp/interactivechat/InteractiveChat.java
@@ -525,7 +525,9 @@ public class InteractiveChat extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerUtils(), this);
         getServer().getPluginManager().registerEvents(new MapViewer(), this);
 
-        protocolPlatform.initialize();
+        // Register the packet listener only if it is our own (ProtocolLib).
+        // An external provider must initialize ONCE the external plugin is initialized.
+        if (protocolPlatform instanceof ProtocolLibPlatform) protocolPlatform.initialize();
         OutTabCompletePacketHandler.init();
 
         if (version.isNewerOrEqualTo(MCVersion.V1_19)) {


### PR DESCRIPTION
If this does not happen, it will attempt to initialize the external plugin's platform while it is not yet loaded - this is because an external plugin would depend on IC in plugin.yml, meaning it must load fully first.