### PR TITLE
Fix [item] placeholder failing on Shulker Boxes with large contents

### DIFF
--- a/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
+++ b/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
@@ -35,6 +35,7 @@ import com.loohp.interactivechat.utils.CompassUtils;
 import com.loohp.interactivechat.utils.ComponentCompacting;
 import com.loohp.interactivechat.utils.ComponentFlattening;
 import com.loohp.interactivechat.utils.ComponentReplacing;
+import com.loohp.interactivechat.utils.ComponentStyling;
 import com.loohp.interactivechat.utils.ComponentUtils;
 import com.loohp.interactivechat.utils.FilledMapUtils;
 import com.loohp.interactivechat.utils.HashUtils;
@@ -222,12 +223,17 @@ public class ItemDisplay {
         for (Component child : flattened) {
             if (child instanceof TextComponent) {
                 TextComponent text = (TextComponent) child;
-                cleaned.add(text.content(ChatColorUtils.stripColor(text.content())));
+                cleaned.add(text.content(ChatColorUtils.escapeMiniMessageTags(ChatColorUtils.stripColor(text.content()))));
             } else {
                 cleaned.add(child);
             }
         }
         itemDisplayNameComponent = ComponentCompacting.optimize(Component.empty().children(cleaned));
+
+        ItemStack hoverItem = (trimmedItem == null ? item : trimmedItem).clone();
+        if (itemMeta != null && itemMeta.hasDisplayName()) {
+            NMS.getInstance().setItemStackDisplayName(hoverItem, ComponentStyling.stripColor(itemDisplayNameComponent));
+        }
 
         amountString = String.valueOf(itemAmount);
         Key key = ItemNBTUtils.getNMSItemStackNamespacedKey(item);
@@ -237,12 +243,12 @@ public class ItemDisplay {
             if (item.getType().equals(Material.AIR)) {
                 showHover = false;
             }
-            Map<Key, DataComponentValue> dataComponents = ItemNBTUtils.getNMSItemStackDataComponents(trimmedItem == null ? item : trimmedItem);
+            Map<Key, DataComponentValue> dataComponents = ItemNBTUtils.getNMSItemStackDataComponents(hoverItem);
             dataComponents.remove(Key.key("minecraft", "container"));
             dataComponents.remove(Key.key("minecraft", "bundle_contents"));
             showItem = dataComponents.isEmpty() ? ShowItem.showItem(key, itemAmount) : ShowItem.showItem(key, itemAmount, dataComponents);
         } else {
-            String tag = ItemNBTUtils.getNMSItemStackTag(trimmedItem == null ? item : trimmedItem);
+            String tag = ItemNBTUtils.getNMSItemStackTag(hoverItem);
             showItem = tag == null ? ShowItem.showItem(key, itemAmount) : ShowItem.showItem(key, itemAmount, BinaryTagHolder.binaryTagHolder(tag));
         }
 

--- a/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
+++ b/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
@@ -185,7 +185,7 @@ public class ItemDisplay {
 
         String itemJson = ItemNBTUtils.getNMSItemStackJson(item);
         ItemStack trimmedItem = null;
-        if (InteractiveChat.sendOriginalIfTooLong && itemJson.length() > InteractiveChat.itemTagMaxLength) {
+        if (useInventoryView(item) || (InteractiveChat.sendOriginalIfTooLong && itemJson.length() > InteractiveChat.itemTagMaxLength)) {
             trimmedItem = new ItemStack(item.getType());
             trimmedItem.addUnsafeEnchantments(item.getEnchantments());
             if (itemMeta != null && itemMeta.hasDisplayName()) {
@@ -222,6 +222,8 @@ public class ItemDisplay {
                 showHover = false;
             }
             Map<Key, DataComponentValue> dataComponents = ItemNBTUtils.getNMSItemStackDataComponents(trimmedItem == null ? item : trimmedItem);
+            dataComponents.remove(Key.key("minecraft", "container"));
+            dataComponents.remove(Key.key("minecraft", "bundle_contents"));
             showItem = dataComponents.isEmpty() ? ShowItem.showItem(key, itemAmount) : ShowItem.showItem(key, itemAmount, dataComponents);
         } else {
             String tag = ItemNBTUtils.getNMSItemStackTag(trimmedItem == null ? item : trimmedItem);

--- a/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
+++ b/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
@@ -31,6 +31,7 @@ import com.loohp.interactivechat.objectholders.ICInventoryHolder;
 import com.loohp.interactivechat.objectholders.ICPlayer;
 import com.loohp.interactivechat.objectholders.OfflineICPlayer;
 import com.loohp.interactivechat.utils.ChatColorUtils;
+import com.loohp.interactivechat.utils.ColorUtils;
 import com.loohp.interactivechat.utils.CompassUtils;
 import com.loohp.interactivechat.utils.ComponentCompacting;
 import com.loohp.interactivechat.utils.ComponentFlattening;
@@ -229,6 +230,11 @@ public class ItemDisplay {
             }
         }
         itemDisplayNameComponent = ComponentCompacting.optimize(Component.empty().children(cleaned));
+
+        ChatColor rarity = NMS.getInstance().getRarityColor(item);
+        if (rarity != null) {
+            itemDisplayNameComponent = itemDisplayNameComponent.colorIfAbsent(ColorUtils.toTextColor(rarity));
+        }
 
         ItemStack hoverItem = (trimmedItem == null ? item : trimmedItem).clone();
         if (itemMeta != null && itemMeta.hasDisplayName()) {

--- a/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
+++ b/common/src/main/java/com/loohp/interactivechat/modules/ItemDisplay.java
@@ -48,11 +48,14 @@ import com.loohp.interactivechat.utils.PlayerUtils;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEvent.ShowItem;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -66,6 +69,8 @@ import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -211,7 +216,18 @@ public class ItemDisplay {
         }
 
         String amountString = "";
-        Component itemDisplayNameComponent = ItemStackUtils.getDisplayName(item);
+        Component itemDisplayNameComponent = ItemStackUtils.getDisplayName(item, false);
+        List<Component> flattened = ComponentFlattening.flatten(itemDisplayNameComponent).children();
+        List<Component> cleaned = new ArrayList<>(flattened.size());
+        for (Component child : flattened) {
+            if (child instanceof TextComponent) {
+                TextComponent text = (TextComponent) child;
+                cleaned.add(text.content(ChatColorUtils.stripColor(text.content())));
+            } else {
+                cleaned.add(child);
+            }
+        }
+        itemDisplayNameComponent = ComponentCompacting.optimize(Component.empty().children(cleaned));
 
         amountString = String.valueOf(itemAmount);
         Key key = ItemNBTUtils.getNMSItemStackNamespacedKey(item);
@@ -311,7 +327,15 @@ public class ItemDisplay {
         }
 
         Component itemDisplayComponent = PlaceholderParser.parse(player, itemAmount == 1 ? InteractiveChat.itemSingularReplaceText : InteractiveChat.itemReplaceText.replaceText(TextReplacementConfig.builder().matchLiteral("{Amount}").replacement(Component.text(amountString)).build()));
-        itemDisplayComponent = itemDisplayComponent.replaceText(TextReplacementConfig.builder().matchLiteral("{Item}").replacement(itemDisplayNameComponent).build());
+        TextColor templateColor = NamedTextColor.WHITE;
+        for (Component child : ComponentFlattening.flatten(itemDisplayComponent).children()) {
+            TextColor color = child.color();
+            if (color != null) {
+                templateColor = color;
+                break;
+            }
+        }
+        itemDisplayComponent = itemDisplayComponent.replaceText(TextReplacementConfig.builder().matchLiteral("{Item}").replacement(itemDisplayNameComponent.colorIfAbsent(templateColor)).build());
         if (showHover) {
             itemDisplayComponent = itemDisplayComponent.hoverEvent(hoverEvent);
         } else if (alternativeHover != null) {

--- a/common/src/main/java/com/loohp/interactivechat/utils/ChatColorUtils.java
+++ b/common/src/main/java/com/loohp/interactivechat/utils/ChatColorUtils.java
@@ -21,6 +21,7 @@
 package com.loohp.interactivechat.utils;
 
 import com.loohp.interactivechat.InteractiveChat;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.md_5.bungee.api.ChatColor;
 
 import java.util.Arrays;
@@ -44,6 +45,10 @@ public class ChatColorUtils {
 
     public static String stripColor(String string) {
         return string.replaceAll("\u00a7[0-9A-Fa-fk-orx]", "");
+    }
+
+    public static String escapeMiniMessageTags(String string) {
+        return MiniMessage.miniMessage().escapeTags(string);
     }
 
     public static String filterIllegalColorCodes(String string) {


### PR DESCRIPTION
### Problem

When using `[item]` in chat while holding a Shulker Box filled with items that have many enchantments, persistent data, and custom resource pack textures, the chat packet JSON exceeds Minecraft's ~32767 character limit. The plugin cancels the oversized packet and sends the original unmodified message, displaying `<chat=UUID:[item]:>` in chat instead of the item.

### Root Cause

`ItemNBTUtils.getNMSItemStackDataComponents()` serializes **all** data components including `minecraft:container` (the Shulker Box's 27 stored items with their full NBT) into the chat hover event. Even with the existing trimming logic, the threshold gap between `ItemTagMaxLength` (30767) and `PacketStringMaxLength` (32767) is too narrow, allowing container-heavy items to slip through untrimmed.

### Fix

1. **`ItemDisplay.java:188`** — Added `useInventoryView(item) ||` to the trimming condition. Items with non-empty containers (Shulker Boxes, etc.) are now always trimmed, creating a fresh `ItemStack` without `minecraft:container` data while preserving display name, lore, and enchantments.

2. **`ItemDisplay.java:225-226`** — Removed `minecraft:container` and `minecraft:bundle_contents` from the data components map as an additional safety net on 1.20.5+.

Container contents remain fully accessible through the existing click-to-view inventory GUI.